### PR TITLE
Add CPU full name and OS info

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,7 @@
 # System Hardware Inspector
 
 Este repositorio incluye un script en Python que muestra la información de hardware del sistema en una interfaz gráfica moderna basada en PyQt5.
-La aplicación detalla ahora la marca, tipo, velocidad y capacidad de cada módulo de memoria RAM.
+La aplicación detalla ahora la marca, tipo, velocidad y capacidad de cada módulo de memoria RAM. También presenta el nombre completo del CPU y al final de la lista indica el sistema operativo en uso.
 
 ## Requisitos
 - Python 3.8+


### PR DESCRIPTION
## Summary
- fetch full CPU name from the system
- include CPU full name in the info report
- show the user's OS at the end
- document these new details in the readme

## Testing
- `python -m py_compile system_hardware_inspector.py`
- `python system_hardware_inspector.py` *(fails: Could not load the Qt platform plugin)*

------
https://chatgpt.com/codex/tasks/task_e_684e3130843883288703f52eed059a81