### PR TITLE
Fix credential path resolution for packaged executable

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -36,3 +36,12 @@ Instala PyInstaller y ejecuta:
 pyinstaller --onefile --windowed system_hardware_inspector.py
 ```
 El ejecutable aparecerá en la carpeta `dist`.
+
+Para que el binario pueda cargar las credenciales, copiá los archivos
+`.env.secure` y `.key` junto al `.exe` o agregalos al momento de compilar:
+
+```bash
+pyinstaller --onefile --windowed \
+    --add-data ".env.secure;." --add-data ".key;." \
+    system_hardware_inspector.py
+```

--- a/system_hardware_inspector.py
+++ b/system_hardware_inspector.py
@@ -234,8 +234,20 @@ def gather_hardware_info() -> str:
     return info
 
 
+def _resource_path(name: str) -> Path:
+    """Return absolute path to resource, compatible with PyInstaller."""
+    if getattr(sys, "frozen", False):
+        base = Path(sys._MEIPASS)
+    else:
+        base = Path(__file__).resolve().parent
+    return base / name
+
+
 def _load_secure_env(secure_path: Path = Path(".env.secure"), key_path: Path = Path(".key")) -> None:
     """Load encrypted environment variables into os.environ."""
+    secure_path = _resource_path(secure_path.name)
+    key_path = _resource_path(key_path.name)
+
     if not secure_path.exists() or not key_path.exists():
         raise FileNotFoundError("Archivos de credenciales no encontrados")
 


### PR DESCRIPTION
## Summary
- handle `.env.secure` and `.key` when the app is frozen with PyInstaller
- document how to include the credential files when building

## Testing
- `python -m py_compile system_hardware_inspector.py`


------
https://chatgpt.com/codex/tasks/task_e_684edcece0a8832897cbeb67f87c7d72