### PR TITLE
Fix .exe build step in workflow

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -29,10 +29,7 @@ jobs:
         run: python setup_keys.py
 
       - name: Build executable
-        run: |
-          pyinstaller --onefile --windowed ^
-            --add-data '.env.secure;.' --add-data '.key;.' ^
-            system_hardware_inspector.py
+        run: pyinstaller --onefile --windowed --add-data '.env.secure;.' --add-data '.key;.' system_hardware_inspector.py
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- fix build executable step in workflow to use PowerShell-compatible syntax

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f3976041c8328aae4ebfe3121ba20